### PR TITLE
Remove ownership verification file

### DIFF
--- a/030e2036-6e28-422d-8e4e-b6620a3d846f
+++ b/030e2036-6e28-422d-8e4e-b6620a3d846f
@@ -1,1 +1,0 @@
-neo-24821695-2684-4fe3-acec-e1d21f9e74de-Sagittal-ai/notion-exporter


### PR DESCRIPTION
This pull request removes the file `030e2036-6e28-422d-8e4e-b6620a3d846f`, which was used to prove Neo's ownership. This change fixes #2 by deleting the unnecessary file, ensuring that the repository no longer contains this verification artifact.